### PR TITLE
fix: Fix to reset isInVictory

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -911,6 +911,7 @@ function sortCards(cards) {
 function startNewGame(cards, board, seed) {
 	clearInterval(looper);
 	looper = undefined;
+	isInVictory = false;
 
 	// TODO: start cards face down in the flower slot, then move them into place.
 


### PR DESCRIPTION
When I have played this game, I found that pressing "New Game" while playing won-animation make the next game doesn't increment the win count.

So I fixed to reset `isInVictory` on starting the new game.
