### PR TITLE
Add music

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Preview image](http://i.imgur.com/pSFk7Jr.jpg)
 
-Yes, this is in the browser! This is a replication of the addictive solitaire game from SHENZHEN I/O. It can use original graphics from the game for a near-identical experience, but without having to keep the game running. The graphic files are not included, however, and must be copied from your installation of the game.
+Yes, this is in the browser! This is a replication of the addictive solitaire game from SHENZHEN I/O. It can use original graphics from the game for a near-identical experience, but without having to keep the game running. The graphics and audio are not included, however, and must be copied from your installation of the game.
 
 _This project is not associated with Zachtronics or [SHENZHEN I/O](http://store.steampowered.com/app/504210/)._
 
@@ -10,7 +10,7 @@ _This project is not associated with Zachtronics or [SHENZHEN I/O](http://store.
 
 <http://tgratzer.com/shenzhen-solitaire/>
 
-If you own the game you can use the base game's graphics. See the next step:
+If you own the game you can use the base game's graphics and music. See the next step:
 
 ## How to install
 
@@ -18,5 +18,6 @@ If you own the game you can use the base game's graphics. See the next step:
 2. Locate the SHENZHEN I/O solitaire textures folder from your installation.
    This will be something like `steamapps\common\SHENZHEN IO\Content\textures\solitaire`
 3. Copy the contents of that folder into the `solitaire` folder in the project.
-4. Open index.html in your browser.
-5. (If you don't own SHENZHEN I/O, you can still play the game, but it's not nearly as pretty.)
+4. (Optional) Find and copy the music (`Content\music\Solitaire.ogg`) into the `solitaire` folder.
+5. Open index.html in your browser.
+6. (If you don't own SHENZHEN I/O, you can still play the game, but it's not nearly as pretty.)

--- a/css/style.css
+++ b/css/style.css
@@ -221,6 +221,10 @@ a, button, .btn-dragon, .bottom-button, .bottom-button * {
 	text-align: center;
 }
 
+.bottom-button.music {
+	display: none;
+}
+
 .bottom-button:hover {
 	background-image: url(../assets/button_bottom_hover.png);
 }

--- a/index.html
+++ b/index.html
@@ -102,9 +102,10 @@
 
 			<h3>About</h3>
 			<p>
-				Adaptation created by Taylor Gratzer. Original gameplay concept by Zachtronics, from the game <a
-					href="http://store.steampowered.com/app/504210/">SHENZHEN
-					I/O</a>. <a href="https://github.com/Nickardson/shenzhen-solitaire">GitHub Repo</a>
+				Adaptation created by Taylor Gratzer. Original gameplay concept by Zachtronics, from the game
+				<a href="http://store.steampowered.com/app/504210/">SHENZHEN I/O</a>.
+				<a href="https://zachtronics.bandcamp.com/track/patience">Music</a> by Matthew S Burns.
+				<a href="https://github.com/Nickardson/shenzhen-solitaire">GitHub Repo</a>
 			</p>
 			<p>Ideas? Comments? <a href="http://tgratzer.com/contact">Send me a message!</a></p>
 			<div id="image_load_error"></div>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
 			<button class="bottom-button" id="newGame">New Game</button>
 			<!-- <button class="bottom-button" id="seedGame">Seed Game</button> -->
 			<button class="bottom-button" id="retryGame">Retry Game</button>
+			<button class="bottom-button music" id="playMusicButton">Play Music</button>
+			<button class="bottom-button music" id="pauseMusicButton">Pause Music</button>
 			<label id="toggleColorblindContainer" class="bottom-button" for="toggleColorblind">
 				<input type="checkbox" id="toggleColorblind" name="toggleColorblind" /> Colorblind
 			</label>

--- a/js/main.js
+++ b/js/main.js
@@ -1207,10 +1207,10 @@ $(document).ready(function () {
 
 	music = new Audio("solitaire/Solitaire.ogg");
 	music.loop = true;
-    $(music).on('canplay', function() {
+	$(music).on('canplay', function() {
 		$('#playMusicButton').show();
 		$(music).off('canplay');
-    })
+	})
 	$(music).on('error', function (_data, _handler) {
 		console.warn('Couldn\'t load music from the original game. If you own SHENZHEN I/O, copy "Content/music/Solitaire.ogg" from the game into the "solitaire" directory of the cloned repository.');
 	});

--- a/js/main.js
+++ b/js/main.js
@@ -201,6 +201,9 @@ var SLOTS = {
 	]
 };
 
+// Audio element for OST
+var music = null;
+
 jQuery.fn.visible = function () {
 	return this.css('visibility', 'visible');
 };
@@ -1079,6 +1082,21 @@ $(document).ready(function () {
 		}
 	});
 
+	$('#playMusicButton').click(function() {
+		music.play();
+		if (music.currentTime > 0 && music.currentTime < 5) {
+			music.currentTime = 0;
+		}
+		$('#playMusicButton').hide();
+		$('#pauseMusicButton').show();
+	});
+
+	$('#pauseMusicButton').click(function() {
+		music.pause();
+		$('#playMusicButton').show();
+		$('#pauseMusicButton').hide();
+	});
+
 	$('#toggleColorblind').change(function (event) {
 		setColorblindMode(event.target.checked);
 	});
@@ -1186,6 +1204,16 @@ $(document).ready(function () {
 
 	// start the canary check
 	$('#canary').attr('src', 'solitaire/button_red_up.png');
+
+	music = new Audio("solitaire/Solitaire.ogg");
+	music.loop = true;
+    $(music).on('canplay', function() {
+		$('#playMusicButton').show();
+		$(music).off('canplay');
+    })
+	$(music).on('error', function (_data, _handler) {
+		console.warn('Couldn\'t load music from the original game. If you own SHENZHEN I/O, copy "Content/music/Solitaire.ogg" from the game into the "solitaire" directory of the cloned repository.');
+	});
 
 	$('html').keydown(function () { }); // UI breakpoint for debugging in Chrome
 


### PR DESCRIPTION
This PR adds instructions to copy the game's music into the `solitaire` directory, and adds some simple buttons to control playback. The music loops, but does not autoplay. The buttons do not appear if the music is not present, and the presence of game music has no effect on loading game assets.

I could maybe invest a bit more time into this and add separate image buttons for play/pause/stop. Maybe I could add a "depressed" style for the buttons? If I did that, I'd probably also change the colorblind button to use the depressed state. In any case, I'm happy to get feedback here.

**Note: I haven't checked the filename for the music on Windows, so definitely confirm it's still Solitaire.ogg there.**

Context: I play this game regularly to take a break from actual work. Can't install Steam on a work computer, so the web version is my only option. The experience isn't the same without the soundtrack. Up till now, I've just been manually playing the song on my phone, but I realized this was silly.