### PR TITLE
Don't highlight dragon cards during a drag

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -786,6 +786,9 @@ function dragonBtnListener(b) {
  */
 function dragonEnterLeaveListener(b, isEnter) {
 	return function () {
+		if (dragging) {
+			return;
+		}
 		var cards = getSpecialCards(b.type);
 
 		for (var i = 0; i < cards.length; i++) {
@@ -1042,6 +1045,7 @@ function getStackFromCardElement(cardElement) {
 }
 
 var cards;
+var dragging = false;
 $(document).ready(function () {
 
 	if (useLocalStorage) {
@@ -1171,6 +1175,7 @@ $(document).ready(function () {
 				for (i = 0; i < stack.length; i++) {
 					stack[i].element.invisible();
 				}
+				dragging = true;
 			} else {
 				event.stopPropagation();
 				event.stopImmediatePropagation();
@@ -1178,6 +1183,7 @@ $(document).ready(function () {
 			}
 		},
 		stop: function (_event, _ui) {
+			dragging = false;
 			var card = $(this).data('card');
 
 			var cardIndex = card.slot.cards.indexOf(card),


### PR DESCRIPTION
Most of the time, when dragging cards, the dragged card helper receives mouse events instead of whatever is underneath those cards. But if the mouse moves fast enough, it's possible to get the mouseenter event on a dragon button while before the dragged cards catch up and cover it, causing a distracting flicker on the matching dragon cards.

This adds a global that is set while a drag is in progress, allowing the mouseover events to exit early and not produce the flicker.