### PR TITLE
Fix inconsistent highlight colors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,11 +66,11 @@ a {
 	z-index: 1;
 }
 
-.card.card-highlight:not(.grand_dragon) {
+.card.card-highlight:not(.grand_dragon.card-reverse) {
 	background-image: linear-gradient( rgba(16, 125, 76, 0.5), rgba(255, 255, 255, 0)), url(../solitaire/card_front.png);
 }
 
-.card.card-highlight.grand_dragon {
+.card.card-reverse.card-highlight.grand_dragon {
 	filter: brightness(1.2) !important;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -955,6 +955,10 @@ function startNewGame(cards, board, seed) {
 	$('.btn-dragon').data('complete', false);
 	placeCardsInTray(cards, board, SLOTS.TRAY); // place cards
 	$('.card').visible();
+
+    // Remove grand dragon class
+	$('.card-special').removeClass('grand_dragon');
+	$('.card-special').removeClass('grand_dragon_2');
 }
 
 function updateWinCount() {


### PR DESCRIPTION
**Description**
There are currently some inconsistencies with dragon highlight colors. This effects users with more than 100 wins. Anytime the user opens the game in a new tab, dragon cards will be highlighted green whenever they hover over the "Move Dragons" button. However, if they successfully move all dragons of a given color, then that color dragon will be highlighted white for the rest of their games.

**Steps to Reproduce**
1. Open shenzhen solitaire in a new tab. Ensure you have more than 100 wins by updating `shenzhen_win_count` value in local storage.
2. Hover your cursor over the "Move Dragons" buttons. Notice that they all are highlighted green
3. Clear all of the dragons of a given color
4. Start a new game in the same tab
5. Hover your cursor over the "Move Dragons" buttons. Notice that the dragons you cleared in the previous game now highlight white, whereas the other colors are still highlighted green.

**Solution**
This was caused by unclear css rules and the `grand_dragon` css class not being removed between games. I'm assuming that grand dragons should only be highlighted in white when they are flipped over.